### PR TITLE
Commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ def get_microphone_stream():
 
 def getParameter(parameters, attr="", integer=False):
     if integer: 
-        return parameters.fields["number-integer"].list_value.values[0].number_value
+        return int(parameters.fields["number-integer"].list_value.values[0].number_value)
     return parameters.fields[attr].string_value.strip()
 
 def main():

--- a/main.py
+++ b/main.py
@@ -11,43 +11,62 @@ def get_microphone_stream():
     microphone.askUserForInputDevice()
     return microphone.getMicrophoneStream()
 
+def getParameter(parameters, attr="", integer=False):
+    if integer: 
+        return parameters.fields["number-integer"].list_value.values[0].number_value
+    return parameters.fields[attr].string_value.strip()
+
 def main():
     microphone_stream = get_microphone_stream()
+    pkmnActions = PokemonActions()
     while True:
         print(20 * "=")
         print("Listening for user action...")
         intent, parameters = detectIntentFromSpeech(microphone_stream)
-        pkmnActions = PokemonActions()
 
-        if intent == Intents.GO:
-            pressReleaseKey(NoGbaMappings.A)
-        elif intent == Intents.BACK:
-            pressReleaseKey(NoGbaMappings.B)
-        elif intent == Intents.UP:
-            pressReleaseKey(NoGbaMappings.UP)
-        elif intent == Intents.DOWN:
-            pressReleaseKey(NoGbaMappings.DOWN)
-        elif intent == Intents.LEFT:
-            pressReleaseKey(NoGbaMappings.LEFT)
-        elif intent == Intents.RIGHT:
-            pressReleaseKey(NoGbaMappings.RIGHT)
-        elif intent == Intents.START:
-            pressReleaseKey(NoGbaMappings.START)
-        elif intent == Intents.NO:
-            pkmnActions.answerNo()
-        elif intent == Intents.DIR_N_STEPS:
-            try:
-                direction = parameters.fields["direction"].string_value.strip()
-                steps = int(parameters.fields["number-integer"].list_value.values[0].number_value)
+        try: 
+            if intent == Intents.GO:
+                pressReleaseKey(NoGbaMappings.A)
+            elif intent == Intents.BACK:
+                pressReleaseKey(NoGbaMappings.B)
+            elif intent == Intents.UP:
+                pressReleaseKey(NoGbaMappings.UP)
+            elif intent == Intents.DOWN:
+                pressReleaseKey(NoGbaMappings.DOWN)
+            elif intent == Intents.LEFT:
+                pressReleaseKey(NoGbaMappings.LEFT)
+            elif intent == Intents.RIGHT:
+                pressReleaseKey(NoGbaMappings.RIGHT)
+            elif intent == Intents.START:
+                pressReleaseKey(NoGbaMappings.START)
+            elif intent == Intents.NO:
+                pkmnActions.answerNo()
+            elif intent == Intents.DIR_N_STEPS:
+                direction =  getParameter(parameters, "Direction")
+                steps = getParameter(parameters, integer=True)
                 pkmnActions.walk(direction, steps)
-            except:
-                print("error")
-        elif intent == Intents.FIGHT:
-            print("Fight keyaction")
-        elif intent == Intents.QUIT:
-            break
-        else:
-            print("No keyaction")
+            elif intent == Intents.FIGHT:
+                print("Fight keyaction")
+            elif intent == Intents.CHOOSE_PKMN:
+                chosen = getParameter(parameters, "Pokemon")
+                if(chosen in pkmnActions.pkmnOrder):
+                    pkmnActions.switchPkmn(chosen)  
+            elif intent == Intents.SUMMARY:
+                chosen = getParameter(parameters, "Pokemon")
+                if(chosen in pkmnActions.pkmnOrder):
+                    pkmnActions.viewPkmnSummary(chosen)
+            elif intent == Intents.CHANGE_PAGE:
+                way = getParameter(parameters, "Way")
+                pkmnActions.changePage(way)
+            elif intent == Intents.ATTACK:
+                attack = getParameter(parameters, "Attack")
+                pkmnActions.useAttack(attack)
+            elif intent == Intents.QUIT:
+                break
+            else:
+                print("No keyaction")
+        except Exception as error:
+                print(error)          
 
 if __name__ == "__main__":
     main()

--- a/src/intents.py
+++ b/src/intents.py
@@ -11,4 +11,13 @@ class Intents:
     RIGHT = "Right"
     GO = "Go"
     NO = "No"
-    QUIT = "Quit"
+    QUIT = "Quit",
+    CHOOSE_PKMN = "Pokemon, I choose you!"
+    SUMMARY = "Show summary for Pokemon"
+    CHANGE_PAGE = "Change page"
+    ATTACK = "Attack"
+
+class Entities:
+    NEXT = "Next"
+    PREVIOUS = "Previous"
+

--- a/src/keystrokes.py
+++ b/src/keystrokes.py
@@ -64,7 +64,8 @@ def releaseKey(hexKeyCode):
     x = Input( ctypes.c_ulong(1), ii_ )
     ctypes.windll.user32.SendInput(1, ctypes.pointer(x), ctypes.sizeof(x))
 
-def pressReleaseKey(hexKeyCode, delay=0.2):
+def pressReleaseKey(hexKeyCode, duration=0.2, sleep=0):
     pressKey(hexKeyCode)
-    time.sleep(delay)
+    time.sleep(duration)
     releaseKey(hexKeyCode)
+    time.sleep(sleep)

--- a/src/nogba_mappings.py
+++ b/src/nogba_mappings.py
@@ -32,11 +32,7 @@ class AttackIndex:
 
 class PokemonActions:
     def __init__(self): 
-        self.pkmnOrder = [
-            Pokémon.CHARMANDER,
-            Pokémon.SPEAROW,
-            Pokémon.CATERPIE
-        ]
+        self.resetPkmnOrder()
         self.attacks = {
             "Scratch": 0,
             "Peck": 0,
@@ -48,7 +44,15 @@ class PokemonActions:
             "Metal claw": 3
         }
 
+    def resetPkmnOrder(self):
+        self.pkmnOrder = [
+            Pokémon.CHARMANDER,
+            Pokémon.SPEAROW,
+            Pokémon.CATERPIE
+        ]
+
     def walk(self, direction, steps):
+        self.resetPkmnOrder()
         key = NoGbaMappings.UP
         if direction == Intents.UP:
             key = NoGbaMappings.UP

--- a/src/nogba_mappings.py
+++ b/src/nogba_mappings.py
@@ -1,5 +1,5 @@
 from src.keystrokes import HexKeyCodes, pressReleaseKey
-from src.intents import Intents
+from src.intents import Intents, Entities
 
 class NoGbaMappings:
     UP = HexKeyCodes.Q
@@ -15,7 +15,39 @@ class NoGbaMappings:
     X = HexKeyCodes.X
     Y = HexKeyCodes.Z
 
+class Pokémon:
+    CHARMANDER = 'Charmander'
+    SPEAROW = 'Spearow'
+    CATERPIE = 'Caterpie'
+
+class AttackIndex:
+    SCRATCH = 0
+    PECK = 0
+    TACKLE = 0
+    GROWL = 1
+    STRING_SHOT = 1
+    EMBER = 1
+    LEER = 2
+    METAL_CLAW = 3
+
 class PokemonActions:
+    def __init__(self): 
+        self.pkmnOrder = [
+            Pokémon.CHARMANDER,
+            Pokémon.SPEAROW,
+            Pokémon.CATERPIE
+        ]
+        self.attacks = {
+            "Scratch": 0,
+            "Peck": 0,
+            "Tackle": 0,
+            "Growl": 1,
+            "String shot": 1,
+            "Ember": 1,
+            "Leer": 2,
+            "Metal claw": 3
+        }
+
     def walk(self, direction, steps):
         key = NoGbaMappings.UP
         if direction == Intents.UP:
@@ -32,3 +64,53 @@ class PokemonActions:
     def answerNo(self):
         pressReleaseKey(NoGbaMappings.DOWN)
         pressReleaseKey(NoGbaMappings.A)
+
+    def selectPkmn(self, chosen):
+        #TODO Add Adam's "go_to_main_menu_state" function
+        pressReleaseKey(NoGbaMappings.DOWN)
+        pressReleaseKey(NoGbaMappings.A, sleep=1.5)
+        chosenIndex = self.pkmnOrder.index(chosen)
+        for i in range(0, chosenIndex):
+            pressReleaseKey(NoGbaMappings.DOWN, sleep=0.2)
+        pressReleaseKey(NoGbaMappings.A, sleep=0.2)
+        return chosenIndex
+
+    def switchPkmn(self, chosen):
+        chosenIndex = self.selectPkmn(chosen)
+        self.pkmnOrder[chosenIndex], self.pkmnOrder[0] = self.pkmnOrder[0], self.pkmnOrder[chosenIndex] 
+        pressReleaseKey(NoGbaMappings.A)
+
+    def viewPkmnSummary(self, chosen):
+        self.selectPkmn(chosen)
+        pressReleaseKey(NoGbaMappings.DOWN, sleep=0.2)
+        pressReleaseKey(NoGbaMappings.A, sleep=0.2)
+        pressReleaseKey(NoGbaMappings.A)
+
+    def changePage(self, way):
+        if way == Entities.NEXT:
+            pressReleaseKey(NoGbaMappings.RIGHT)
+        elif way == Entities.PREVIOUS:
+            pressReleaseKey(NoGbaMappings.LEFT)
+
+    def useAttack(self, attack):
+        #TODO Add Adam's "go_to_main_menu_state" function
+        pressReleaseKey(NoGbaMappings.A, sleep=0.2)
+        pressReleaseKey(NoGbaMappings.UP, sleep=0.2)
+        pressReleaseKey(NoGbaMappings.LEFT, sleep=0.2)
+        
+        if self.attacks[attack] == 0:
+            pressReleaseKey(NoGbaMappings.A)
+        elif self.attacks[attack] == 1:
+            pressReleaseKey(NoGbaMappings.RIGHT, sleep=0.2)
+            pressReleaseKey(NoGbaMappings.A)
+        elif self.attacks[attack] == 2:
+            pressReleaseKey(NoGbaMappings.DOWN, sleep=0.2)
+            pressReleaseKey(NoGbaMappings.A)
+        elif self.attacks[attack] == 3:
+            pressReleaseKey(NoGbaMappings.RIGHT, sleep=0.2)
+            pressReleaseKey(NoGbaMappings.DOWN, sleep=0.2)
+            pressReleaseKey(NoGbaMappings.A)
+
+
+
+


### PR DESCRIPTION
Created an internal state to keep track of Pokémon order. You can now say "Charmander, I choose you!" or "Switch to Spearow" etc to send out a Pokémon. The state is reset when you give a walk command. Each Pokémon's summary can be viewed by saying "View summary for Caterpie" etc. Next page and previous page commands have also been implemented.

Attacks are callable by simply saying their name or saying "use growl" etc. Currently missing a "go_to_main_menu_state" function, will be added later after it has been written.

closes #3 
closes #6 
closes #9